### PR TITLE
feat: improve link handling

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,13 @@
+{{- if or (strings.HasPrefix .Destination "http") (strings.HasPrefix .Destination "#") -}} 
+<a href="{{ .Destination | safeURL }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
+{{- else -}}
+{{- $link := . -}}
+{{- $internal := urls.Parse .Destination -}}
+{{- if $internal.Path -}}
+{{- $fragment := "" }}
+{{- with $internal.Fragment }}{{ $fragment = printf "#%s" . }}{{ end -}}
+{{- with .Page.GetPage $internal.Path }}{{ $internal = printf "%s%s" .RelPermalink $fragment }}
+<a href="{{ $internal }}"{{ with .Title }} title="{{ . }}"{{ end }}>{{ $link.Text | safeHTML }}</a>
+{{- end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Hugo could be better when linking markdown files if they are outside their own folder. With this improvement, we will fetch all relative links, even with `.md,` and generate their url different than the [originial version](https://gohugo.io/templates/render-hooks/#link-with-title-markdown-example).

This change now also allows links to `.md` files within the links, so we don't need to care about this anymore.

In Hugo you can write documentation with two different naming/structuring approaches:
1. `<docName>/_index.md`
2. `<docName>.md`

The problem is that links from files within the second approach could be simpler. Locally and in the Markdown space, they're in the same folder. But when Hugo renders them, there is a folder level in between.

With this approach, we're changing how hugo renders relative files. Rather than blindly using the link for pages within the documentation, we search for that page, and take the link from this page, generate via Hugo. This way we will always have the right directory levels, for markdown and for hugo

relates: https://github.com/keptn/lifecycle-toolkit/pull/1177