### PR TITLE
chore: Manually trigger docs release

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -22,6 +22,27 @@ on:
         type: "boolean"
         default: false
         required: false
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag for the functions runner image / docs version"
+        type: "string"
+        required: true
+      page_dir:
+        description: "Root directory of the website"
+        type: "string"
+        required: false
+        default: "./tmp/page/"
+      docs_dir:
+        description: "Sub directory of documentation"
+        type: "string"
+        required: false
+        default: "./docs"
+      dry_run:
+        description: "Flag for testing"
+        type: "boolean"
+        default: false
+        required: false
 
 jobs:
   release-docs:


### PR DESCRIPTION
# This PR

- Adds a manual `workflow_dispatch` trigger so docs maintainers can build and release docs on-demand